### PR TITLE
Fixes duplicate output messages (issue #6)

### DIFF
--- a/lib/packethandlers.lua
+++ b/lib/packethandlers.lua
@@ -49,17 +49,17 @@ end
 
 -- trying to identify possible dupes
 local reference_buffer = {};
-packethandlers.check_duplicates = function(e)
-    -- resets dupe buffer when starting a new chunk
+
+function check_duplicates(e)
     if ffi.C.memcmp(e.data_raw, e.chunk_data_raw, e.size) == 0 then
-        if cross_checks >= 15 then
+        if cross_checks >= 20 then
             reference_buffer = {};
             cross_checks = 0;
         else
             cross_checks = cross_checks + 1;
         end
     end
-    -- current packet as char{size}
+    
     local packet = struct.unpack('c' .. e.size, e.data, 1)
     local offset = 0;
     
@@ -69,10 +69,7 @@ packethandlers.check_duplicates = function(e)
         local chunk_packet = struct.unpack('c' .. size, e.chunk_data, offset + 1);
 
         if (ffi.C.memcmp(packet, chunk_packet, e.size) == 0) then
-            -- if i put a comment here, the comparison works
             for i, _ in pairs(reference_buffer) do
-                -- but it seems that it never works in this case
-                -- although it keeps sending duplicate packets
                 if (ffi.C.memcmp(packet, reference_buffer[i], e.size) == 0) then
                     e.blocked = true
                     return true
@@ -136,7 +133,7 @@ end
 
 packethandlers.HandleIncomingPacket = function(e)
     
-    if packethandlers.check_duplicates(e) then return end
+    if check_duplicates(e) then return end
 
 	if (e.id == 0x00A) then
 		gPacketHandlers.HandleIncoming0x00A(e);

--- a/lib/packethandlers.lua
+++ b/lib/packethandlers.lua
@@ -6,46 +6,6 @@ ffi.cdef[[
 ]];
 
 local packethandlers = {};
-local cross_checks = 0
-local packetbuffer = {};
-
-function table_print (tt, indent, done)
-    done = done or {}
-    indent = indent or 0
-    if type(tt) == "table" then
-        local sb = {}
-        for key, value in pairs (tt) do
-        table.insert(sb, string.rep (" ", indent)) -- indent it
-        if type (value) == "table" and not done [value] then
-            done [value] = true
-            table.insert(sb, key .. " = {\n");
-            table.insert(sb, table_print (value, indent + 2, done))
-            table.insert(sb, string.rep (" ", indent)) -- indent it
-            table.insert(sb, "}\n");
-        elseif "number" == type(key) then
-            table.insert(sb, string.format("\"%s\"\n", tostring(value)))
-        else
-            table.insert(sb, string.format(
-                "%s = \"%s\"\n", tostring (key), tostring(value)))
-            end
-        end
-        return table.concat(sb)
-    else
-        return tt .. "\n"
-    end
-end
-  
-function to_string( tbl )
-    if  "nil"       == type( tbl ) then
-        return tostring(nil)
-    elseif  "table" == type( tbl ) then
-        return table_print(tbl)
-    elseif  "string" == type( tbl ) then
-        return tbl
-    else
-        return tostring(tbl)
-    end
-end
 
 -- trying to identify possible dupes
 local last_chunk_buffer;

--- a/lib/packethandlers.lua
+++ b/lib/packethandlers.lua
@@ -44,7 +44,6 @@ function check_duplicates(e)
 end
 
 packethandlers.HandleIncoming0x00A = function(e)
-
     local id = struct.unpack('L', e.data, 0x04 + 1);
     local name = struct.unpack('c16', e.data, 0x84 + 1);
     local i,j = string.find(name, '\0');
@@ -80,15 +79,12 @@ packethandlers.DelayedSelfAssign = function ()
 end
 
 packethandlers.HandleIncoming0x28 = function(e)
-
 	local act_org = gActionHandlers.StringToAct(e.data)
 	act_org.size = e.data:byte(5)
 	local act_mod = gActionHandlers.StringToAct(e.data_modified)
 	act_mod.size = e.data_modified:byte(5)
 
-    local packet = gActionHandlers.ActToString(e.data, gActionHandlers.parse_action_packet(act_org, act_mod))
-
-	return packet
+	return gActionHandlers.ActToString(e.data, gActionHandlers.parse_action_packet(act_org, act_mod))
 end
 
 packethandlers.HandleIncomingPacket = function(e)
@@ -97,7 +93,6 @@ packethandlers.HandleIncomingPacket = function(e)
 
 	if (e.id == 0x00A) then
 		gPacketHandlers.HandleIncoming0x00A(e);
-
     elseif (e.id == 0x28) then
         e.data_modified = gPacketHandlers.HandleIncoming0x28(e);
     end

--- a/lib/ui.lua
+++ b/lib/ui.lua
@@ -802,11 +802,10 @@ ui.render_config = function(toggle)
                     end
 
                     ui.updatecolors()
-
                     local colors_inputbox = {}
                     for i, v in ipairs(color_info.color_order) do
                         imgui.PushItemWidth(30)
-                        colors_inputbox[i] = imgui.InputInt(('##%s'):fmt(color_info.color_order[i]), color_info.color_inputs[v], 0)
+                        colors_inputbox[i] = imgui.InputInt(('##%s'):fmt(v), color_info.color_inputs[v], 0)
                         if colors_inputbox[i] then
                             gProfileColor[v] = tonumber(color_info.color_inputs[v][1])
                         end
@@ -831,39 +830,13 @@ ui.render_config = function(toggle)
 end
 
 ui.updatecolors = function ()
-    color_info.color_inputs.mob = { gProfileColor.mob }
-    color_info.color_inputs.other = { gProfileColor.other }
-    color_info.color_inputs.p0 = { gProfileColor.p0 }
-    color_info.color_inputs.p1 = { gProfileColor.p1 }
-    color_info.color_inputs.p2 = { gProfileColor.p2 }
-    color_info.color_inputs.p3 = { gProfileColor.p3 }
-    color_info.color_inputs.p4 = { gProfileColor.p4 }
-    color_info.color_inputs.p5 = { gProfileColor.p5 }
-    color_info.color_inputs.a10 = { gProfileColor.a10 }
-    color_info.color_inputs.a11 = { gProfileColor.a11 }
-    color_info.color_inputs.a12 = { gProfileColor.a12 }
-    color_info.color_inputs.a13 = { gProfileColor.a13 }
-    color_info.color_inputs.a14 = { gProfileColor.a14 }
-    color_info.color_inputs.a15 = { gProfileColor.a15 }
-    color_info.color_inputs.a20 = { gProfileColor.a20 }
-    color_info.color_inputs.a21 = { gProfileColor.a21 }
-    color_info.color_inputs.a22 = { gProfileColor.a22 }
-    color_info.color_inputs.a23 = { gProfileColor.a23 }
-    color_info.color_inputs.a24 = { gProfileColor.a24 }
-    color_info.color_inputs.a25 = { gProfileColor.a25 }
-    color_info.color_inputs.mobdmg = { gProfileColor.mobdmg }
-    color_info.color_inputs.mydmg = { gProfileColor.mydmg }
-    color_info.color_inputs.partydmg = { gProfileColor.partydmg }
-    color_info.color_inputs.allydmg = { gProfileColor.allydmg }
-    color_info.color_inputs.otherdmg = { gProfileColor.otherdmg }
-    color_info.color_inputs.spellcol = { gProfileColor.spellcol }
-    color_info.color_inputs.mobspellcol = { gProfileColor.mobspellcol }
-    color_info.color_inputs.abilcol = { gProfileColor.abilcol }
-    color_info.color_inputs.wscol = { gProfileColor.wscol }
-    color_info.color_inputs.mobwscol = { gProfileColor.mobwscol }
-    color_info.color_inputs.statuscol = { gProfileColor.statuscol }
-    color_info.color_inputs.enfeebcol = { gProfileColor.enfeebcol }
-    color_info.color_inputs.itemcol = { gProfileColor.itemcol }
+    for i, v in pairs(gProfileColor) do
+        if type(v) == 'table' then
+            color_info.color_inputs[i] = v
+        else
+            color_info.color_inputs[i] = T{ v }
+        end
+    end
 end
 
 ui.save_changes = function ()
@@ -878,6 +851,7 @@ ui.save_changes = function ()
     else
         gFileTools.SaveChanges(defaultFiltersFile, gProfileFilter, 'filters')
     end
+    
     gFileTools.SaveChanges(defaultColorsFile, gProfileColor, 'colors')
     print(chat.header('SimpleLog')..chat.success('All changes Saved'))
 end


### PR DESCRIPTION
This should fix the duplication of output messages by filtering repeated packages sent by the server

- fix(packethandlers.lua): first attempt on fixing the duplicate messages
- chore(packethandler): removing comments and changing the function scope
- fix(ui): fixes a crash happening when opening colors tab
