### PR TITLE
Band-Aid  fix for no target crashes

### DIFF
--- a/lib/actionhandlers.lua
+++ b/lib/actionhandlers.lua
@@ -941,6 +941,11 @@ end
 
 actionhandlers.SpellParse = function (act)
     local spell, abil_ID, effect_val = {}
+    -- If the target returns nil, will return No MSG instad of crashing.
+    -- This is a bandaid
+    if(act.targets[1] == nil) then
+        return false;
+    end
     local msg_ID = act.targets[1].actions[1].message
 
     if T{7, 8, 9}:contains(act.category) then


### PR DESCRIPTION
As the title states, this is a Band-Aid that prevents simplelog from crashing when target returns nil. 