### PR TITLE
fix(packethandlers.lua): fixes duplicate messages in instances

### DIFF
--- a/lib/packethandlers.lua
+++ b/lib/packethandlers.lua
@@ -10,7 +10,7 @@ local packethandlers = {};
 -- trying to identify possible dupes
 local last_chunk_buffer;
 local reference_buffer = T{};
-function check_duplicates(e)
+function record_packets(e)
     if ffi.C.memcmp(e.data_raw, e.chunk_data_raw, e.size) == 0 then
         if #reference_buffer > 2 then
             reference_buffer[#reference_buffer] = nil
@@ -30,7 +30,9 @@ function check_duplicates(e)
             offset = offset + size;
         end
     end
+end
 
+function check_duplicates(e)
     local packet = struct.unpack('c' .. e.size, e.data, 1)
     for _, chunk in ipairs(reference_buffer) do
         for _, bufferEntry in ipairs(chunk) do
@@ -88,6 +90,7 @@ packethandlers.HandleIncoming0x28 = function(e)
 end
 
 packethandlers.HandleIncomingPacket = function(e)
+	record_packets(e);
 	if (e.id == 0x00A) then
 		gPacketHandlers.HandleIncoming0x00A(e);
     elseif (e.id == 0x28) then

--- a/simplelog.lua
+++ b/simplelog.lua
@@ -21,7 +21,7 @@
 
 addon.name      = 'simplelog';
 addon.author    = 'Created by Byrth, Ported by Spiken';
-addon.version   = '0.1.1';
+addon.version   = '0.1.2';
 addon.desc      = 'Combat log Parser';
 addon.link      = 'https://github.com/Spike2D/SimpleLog';
 


### PR DESCRIPTION
Per some help from Thorny in the Ashita Discord, this splits the packet detection process for duplicates into a recording part and a dupe checking part. This fixes the duplicate message bug that was occurring in instances such as Ambuscade while not aggressively blocking unrelated packets.